### PR TITLE
:zap: 将 ResponseExcelReturnValueHandler 交由 spring 托管，方便用户继承并做自定义处理

### DIFF
--- a/src/main/java/com/pig4cloud/plugin/excel/ExcelHandlerConfiguration.java
+++ b/src/main/java/com/pig4cloud/plugin/excel/ExcelHandlerConfiguration.java
@@ -1,8 +1,10 @@
 package com.pig4cloud.plugin.excel;
 
 import com.alibaba.excel.converters.Converter;
+import com.pig4cloud.plugin.excel.aop.ResponseExcelReturnValueHandler;
 import com.pig4cloud.plugin.excel.config.ExcelConfigProperties;
 import com.pig4cloud.plugin.excel.handler.ManySheetWriteHandler;
+import com.pig4cloud.plugin.excel.handler.SheetWriteHandler;
 import com.pig4cloud.plugin.excel.handler.SingleSheetWriteHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.ObjectProvider;
@@ -18,7 +20,7 @@ import java.util.List;
  */
 @RequiredArgsConstructor
 @Configuration(proxyBeanMethods = false)
-public class SheetWriteHandlerAutoConfiguration {
+public class ExcelHandlerConfiguration {
 	private final ExcelConfigProperties configProperties;
 	private final ObjectProvider<List<Converter<?>>> converterProvider;
 
@@ -38,6 +40,18 @@ public class SheetWriteHandlerAutoConfiguration {
 	@ConditionalOnMissingBean
 	public ManySheetWriteHandler manySheetWriteHandler() {
 		return new ManySheetWriteHandler(configProperties, converterProvider);
+	}
+
+	/**
+	 * 返回Excel文件的 response 处理器
+	 * @param sheetWriteHandlerList 页签写入处理器集合
+	 * @return ResponseExcelReturnValueHandler
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	public ResponseExcelReturnValueHandler responseExcelReturnValueHandler(
+		List<SheetWriteHandler> sheetWriteHandlerList) {
+		return new ResponseExcelReturnValueHandler(sheetWriteHandlerList);
 	}
 
 }

--- a/src/main/java/com/pig4cloud/plugin/excel/ResponseExcelAutoConfiguration.java
+++ b/src/main/java/com/pig4cloud/plugin/excel/ResponseExcelAutoConfiguration.java
@@ -3,11 +3,9 @@ package com.pig4cloud.plugin.excel;
 import com.pig4cloud.plugin.excel.aop.DynamicNameAspect;
 import com.pig4cloud.plugin.excel.aop.ResponseExcelReturnValueHandler;
 import com.pig4cloud.plugin.excel.config.ExcelConfigProperties;
-import com.pig4cloud.plugin.excel.handler.SheetWriteHandler;
 import com.pig4cloud.plugin.excel.processor.NameProcessor;
 import com.pig4cloud.plugin.excel.processor.NameSpelExpressionProcessor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +14,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.web.method.support.HandlerMethodReturnValueHandler;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
+import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,14 +24,15 @@ import java.util.List;
  * <p>
  * 配置初始化
  */
-@Import(SheetWriteHandlerAutoConfiguration.class)
+@Import(ExcelHandlerConfiguration.class)
 @RequiredArgsConstructor
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(ExcelConfigProperties.class)
-public class ResponseExcelAutoConfiguration implements InitializingBean {
-	private final RequestMappingHandlerAdapter handlerAdapter;
-	private final List<SheetWriteHandler> sheetWriteHandlerList;
+public class ResponseExcelAutoConfiguration {
 
+	private final RequestMappingHandlerAdapter handlerAdapter;
+
+	private final ResponseExcelReturnValueHandler responseExcelReturnValueHandler;
 
 	/**
 	 * SPEL 解析处理器
@@ -55,12 +55,15 @@ public class ResponseExcelAutoConfiguration implements InitializingBean {
 		return new DynamicNameAspect(nameProcessor);
 	}
 
-	@Override
-	public void afterPropertiesSet() {
+	/**
+	 * 追加 Excel返回值处理器 到 springmvc 中
+	 */
+	@PostConstruct
+	public void setReturnValueHandlers() {
 		List<HandlerMethodReturnValueHandler> returnValueHandlers = handlerAdapter.getReturnValueHandlers();
 
 		List<HandlerMethodReturnValueHandler> newHandlers = new ArrayList<>();
-		newHandlers.add(new ResponseExcelReturnValueHandler(sheetWriteHandlerList));
+		newHandlers.add(responseExcelReturnValueHandler);
 		assert returnValueHandlers != null;
 		newHandlers.addAll(returnValueHandlers);
 		handlerAdapter.setReturnValueHandlers(newHandlers);


### PR DESCRIPTION
有时候项目需要对导出的excel标题进行国际化处理，或者对数据做一些特殊处理，如脱敏，或权限控制。

将 ResponseExcelReturnValueHandler 交由 spring 托管，更方便使用者定制化