### PR TITLE
跨域无法获取到后端返回的Content-Disposition文件名称

### DIFF
--- a/src/main/java/com/pig4cloud/plugin/excel/handler/AbstractSheetWriteHandler.java
+++ b/src/main/java/com/pig4cloud/plugin/excel/handler/AbstractSheetWriteHandler.java
@@ -93,6 +93,7 @@ public abstract class AbstractSheetWriteHandler implements SheetWriteHandler, Ap
 			.map(MediaType::toString)
 			.orElse("application/vnd.ms-excel");
 		response.setContentType(contentType);
+		response.setHeader(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION);
 		response.setCharacterEncoding("utf-8");
 		response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename*=utf-8''" + fileName);
 		write(o, response, responseExcel);


### PR DESCRIPTION
response.headers['content-disposition'];
不加此设置返回的流在跨域时前端无法读取